### PR TITLE
Add `create` command

### DIFF
--- a/.changeset/funny-tools-mix.md
+++ b/.changeset/funny-tools-mix.md
@@ -1,0 +1,5 @@
+---
+'@prompt-template/cli': minor
+---
+
+Added `create` command

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -13,6 +13,9 @@ npm i @prompt-template/core @prompt-template/cli
 ## Usage
 
 ```bash
+# Create a new prompt template
+npx @prompt-template/cli create
+
 # Inspect a prompt template
 npx @prompt-template/cli inspect <prompt-template-file>
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -7,6 +7,9 @@ if (!command) {
 }
 
 switch (command) {
+  case 'create':
+    await import('./commands/create.js')
+    break
   case 'format':
     await import('./commands/format.js')
     break

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -1,0 +1,102 @@
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import * as util from 'node:util'
+
+import { generateName } from '../utils/generate-name.js'
+
+const defaultExt = 'ts'
+
+const args = util.parseArgs({
+  options: {
+    name: { type: 'string', short: 'n' },
+    ext: { type: 'string', short: 'e' },
+    'out-dir': { type: 'string' },
+    help: { type: 'boolean', short: 'h' },
+  },
+})
+
+if (args.values.help) {
+  console.log(
+    `
+Usage: npx @prompt-template/cli create [options]
+
+Scaffolds a new prompt template file.
+
+Options:
+  -n, --name <name>      The base name of the file (default: Randomly generated e.g. ${generateName()})
+  -e, --ext <extension>  The file extension (ts, js, mjs, cjs; default: "${defaultExt}")
+  --out-dir <directory>  The output directory (default: process.cwd())
+  -h, --help             Display help text
+`.trim(),
+  )
+  process.exit(0)
+}
+
+const baseName = args.values.name || generateName()
+const extension = args.values.ext || defaultExt
+const outDir = args.values['out-dir'] || '.'
+
+const cwd = process.cwd()
+const fileName = `${baseName}.${extension}`
+const outDirPath = path.resolve(cwd, outDir)
+const filePath = path.join(outDirPath, fileName)
+const fileNameFromCWD = filePath.replace(cwd + path.sep, '')
+
+await fs.promises.mkdir(outDirPath, { recursive: true }).catch(() => {})
+
+if (fs.existsSync(filePath)) {
+  console.error(`Error: File '${filePath}' already exists`)
+  process.exit(1)
+}
+
+const fileContent = `/**
+Usage commands:
+
+# Inspect prompt template
+npx @prompt-template/cli inspect ${fileNameFromCWD}
+
+# Format prompt template
+npx @prompt-template/cli format ${fileNameFromCWD}
+
+# Pipe into your agent of choice
+npx @prompt-template/cli format ${fileNameFromCWD} | example-agent
+*/
+import { PromptTemplate } from '@prompt-template/core';
+
+export default PromptTemplate.create/* md */\`
+# Instructions
+
+(Provide clear and concise instructions for the agent)
+
+## Objective
+
+(State the primary goal or task for the agent)
+
+## Output Format
+
+(Specify the desired format for the agent's response. For example, JSON, markdown, a list, etc.)
+
+(You can add other sections like 'Context', 'Examples', or 'Constraints' if needed)
+\`
+`
+
+await fs.promises.writeFile(filePath, fileContent)
+
+const gray = '\x1b[90m'
+const blue = '\x1b[34m'
+const reset = '\x1b[0m'
+
+console.log(
+  [
+    '',
+    `✅ Prompt template created at ${blue}${fileNameFromCWD}${reset}`,
+    '',
+    `Example usage:`,
+    `${gray}# Inspect prompt template${reset}`,
+    `npx @prompt-template/cli inspect ${fileNameFromCWD}`,
+    '',
+    `${gray}# Format prompt template${reset}`,
+    `npx @prompt-template/cli format ${fileNameFromCWD}`,
+    '',
+  ].join('\n'),
+)

--- a/packages/cli/src/utils/generate-name.ts
+++ b/packages/cli/src/utils/generate-name.ts
@@ -1,0 +1,69 @@
+const adjectives = [
+  'stellar',
+  'radiant',
+  'nimble',
+  'zesty',
+  'brisk',
+  'clever',
+  'bold',
+  'polite',
+  'vivid',
+  'keen',
+  'steady',
+  'bright',
+  'galactic',
+  'curious',
+  'sharp',
+  'swift',
+] as const
+
+const nouns = [
+  'phoenix',
+  'ember',
+  'beacon',
+  'rocket',
+  'otter',
+  'riddle',
+  'signal',
+  'fox',
+  'drone',
+  'gizmo',
+  'whisper',
+  'pixel',
+  'spark',
+  'comet',
+  'puzzle',
+  'switch',
+  'pickle',
+] as const
+
+const verbs = [
+  'sparks',
+  'flows',
+  'soars',
+  'rises',
+  'glides',
+  'drifts',
+  'spins',
+  'clicks',
+  'dances',
+  'sings',
+  'echoes',
+  'twinkles',
+  'shuffles',
+  'hums',
+  'thinks',
+  'flickers',
+] as const
+
+export function generateName(): string {
+  const adjective = pick(adjectives)
+  const noun = pick(nouns)
+  const verb = pick(verbs)
+
+  return `z-${adjective}-${noun}-${verb}`
+}
+
+function pick<T>(list: readonly T[]): T {
+  return list[Math.floor(Math.random() * list.length)] as T
+}


### PR DESCRIPTION
Adds a `create` command to the `@prompt-template/cli`.

The command scaffolds a new prompt template file.

**Example usage**

```
npx @prompt-template/cli create [options]

Options:
  -n, --name <name>      The base name of the file (default: Randomly generated)
  -e, --ext <extension>  The file extension (ts, js, mjs, cjs; default: "ts")
  --out-dir <directory>  The output directory (default: process.cwd())
  -h, --help             Display help text
```

**Example  output**

```
✅ Prompt template created at `z-radiant-gizmo-sparkles.ts`

Example usage:
# Inspect prompt template
npx @prompt-template/cli inspect z-radiant-gizmo-sparkles.ts

# Format prompt template
npx @prompt-template/cli format z-radiant-gizmo-sparkles.ts
```